### PR TITLE
Add hint about fixing all fields updating instead of modified ones

### DIFF
--- a/src/test/java/com/jeeconf/hibernate/basics/flush/FlushTest.java
+++ b/src/test/java/com/jeeconf/hibernate/basics/flush/FlushTest.java
@@ -42,6 +42,7 @@ public class FlushTest extends BaseTest {
     @Test
     @Commit
     public void updateAllFields() {
+        //add @DynamicUpdate to Client
         Client client = session.get(Client.class, 100);
         client.setAge(30);
     }


### PR DESCRIPTION
The only issue which was not resolved in the hibernate basics video is related to all fields update in case when only one or few fields were touched
